### PR TITLE
Addressed issues with accuracy of rounding

### DIFF
--- a/src/capital-gains.ts
+++ b/src/capital-gains.ts
@@ -62,9 +62,9 @@ function calculateCapitalGainsForSale(
       capitalGains += amountSold * (sale.price - buy.price)
     })
 
-  if (sale.amount > 0) {
+  if (Math.round(sale.amount, 4) > 0) {
     throw Error(
-      `Amount of sales for symbol ${sale.symbol} exceeds the amount of buys.`
+      `Amount of sales for symbol ${sale.symbol} exceeds the amount of buys by ${sale.amount}`
     )
   }
 


### PR DESCRIPTION
When checking number of units sold vs units bought there is an issue with accuracy of representation. This has been addressed by rounding the sale.amount to four decimals.

_If there is a linked issue, mention it here._

- [x] Bug
- [ ] Feature

## Requirements

- [ ] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [ ] Wrote tests.
- [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

_Why is this PR necessary?_

## Implementation

_Why have you implemented it this way? Did you try any other methods?_

## Open questions

_Are there any open questions about this implementation that need answers?_

## Other

_Is there anything else we should know? Delete this section if you don't need it._

## Tasks

_List any tasks you need to do here, if any. Delete this section if you don't need it._

- [ ] _Example task._
